### PR TITLE
chore(deps): add dependabot yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:30"
+      timezone: "America/Los_Angeles"
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
@vulcu I don't have access to this, but after this pr is merged, can you please go to Settings > Code security & analysis > Dependabot and enable all three options? I'm happy to handle dependency updates if you like.